### PR TITLE
Add settings for flexible TPU95

### DIFF
--- a/3d Printers/Ultimaker2+/Temp Settings/MATERIAL.TXT
+++ b/3d Printers/Ultimaker2+/Temp Settings/MATERIAL.TXT
@@ -81,3 +81,18 @@ bed_temperature=60
 fan_speed=50
 flow=100
 diameter=2.85
+
+;TPU 95
+[material]
+name=TPU_95
+temperature=235
+temperature_0.40=235
+temperature_0.25=235
+temperature_0.60=235
+temperature_0.80=235
+temperature_1.00=235
+bed_temperature=70
+fan_speed=50
+flow=100
+diameter=2.85
+


### PR DESCRIPTION
Here are some settings for TPU95a 2.85mm. It runs a bit hotter.

Some other notes/findings which I'll just document here (for lack of a better place), as far as printing successfully with the TPU95:

- A brim is pretty much critical. It doesn't adhere to the buildplate quite as well as other materials, so a brim is a must.
- Today, Ultimaker 2+ #7 is doing a bad job. Ultimaker 2+ #8 is doing a good job. The same settings consistently result in an awful print on #7 and a good one on #8. I'm not sure why this is. Maybe the nozzle is dirty and needs cleaning/replacement? I'm able to get #7 to print ok, but I have to slow things way way down.
- I've got some settings for Cura, but nothing surprising or all that distinct from the TPU settings we have stored in Cura already. I'm pretty sure the only reasons this material was giving us so much grief last week were lack of a brim, and printer #7 misbehaving.

That's all!!

👽 👽 👽 